### PR TITLE
Fix Divide by 0 Error

### DIFF
--- a/Assets/hexabuttonScript.cs
+++ b/Assets/hexabuttonScript.cs
@@ -401,7 +401,11 @@ public class hexabuttonScript : MonoBehaviour {
 
             sum %= 10;
 
-            if ((int)Bomb.GetTime() % sum == 0 || sum == 0)
+            if (sum == 0)
+            {
+                answerCorrect = true;
+            }
+            else if((int)Bomb.GetTime() % sum == 0)
             {
                 answerCorrect = true;
             }


### PR DESCRIPTION
Force the module to check if `sum` is 0 first, then if that is incorrect, allow it to modulo by `sum`. 